### PR TITLE
Changes CND to prevent redirections

### DIFF
--- a/src/asciidoctor-emoji.js
+++ b/src/asciidoctor-emoji.js
@@ -21,7 +21,7 @@ function emojiInlineMacro () {
     const emojiUnicode = twemojiMap[target]
     if (emojiUnicode) {
       return self.createInline(parent, 'image', '', {
-        target: `https://twemoji.maxcdn.com/2/svg/${emojiUnicode}.svg`,
+        target: `https://cdn.jsdelivr.net/npm/twemoji@latest/2/svg/${emojiUnicode}.svg`,
         type: 'emoji',
         attributes: {
           alt: target,

--- a/test/test.js
+++ b/test/test.js
@@ -37,7 +37,7 @@ describe('Conversion', () => {
       const registry = asciidoctor.Extensions.create()
       asciidoctorEmoji.register(registry)
       const html = asciidoctor.convert(input, { extension_registry: registry })
-      expect(html).to.contain('<span class="emoji"><img src="https://twemoji.maxcdn.com/2/svg/1f604.svg" alt="smile" width="24px" height="24px"></span>')
+      expect(html).to.contain('<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/twemoji@latest/2/svg/1f604.svg" alt="smile" width="24px" height="24px"></span>')
     })
     it('should return an error message if the emoji does not exist', () => {
       const input = 'emoji:ooops[]'
@@ -52,21 +52,21 @@ describe('Conversion', () => {
     const registry = asciidoctor.Extensions.create()
     asciidoctorEmoji.register(registry)
     const html = asciidoctor.convert(input, { extension_registry: registry })
-    expect(html).to.contain('<span class="emoji"><img src="https://twemoji.maxcdn.com/2/svg/1f385-1f3ff.svg" alt="santa-skin-tone-6" width="34px" height="34px"></span>')
+    expect(html).to.contain('<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/twemoji@latest/2/svg/1f385-1f3ff.svg" alt="santa-skin-tone-6" width="34px" height="34px"></span>')
   })
   it('should convert an existing emoji into an image with the size 4x (68px)', () => {
     const input = 'emoji:beetle[4x]'
     const registry = asciidoctor.Extensions.create()
     asciidoctorEmoji.register(registry)
     const html = asciidoctor.convert(input, { extension_registry: registry })
-    expect(html).to.contain('<span class="emoji"><img src="https://twemoji.maxcdn.com/2/svg/1f41e.svg" alt="beetle" width="68px" height="68px"></span>')
+    expect(html).to.contain('<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/twemoji@latest/2/svg/1f41e.svg" alt="beetle" width="68px" height="68px"></span>')
   })
   it('should convert an existing emoji into an image with the size in pixel (42px)', () => {
     const input = 'emoji:penguin[42px]'
     const registry = asciidoctor.Extensions.create()
     asciidoctorEmoji.register(registry)
     const html = asciidoctor.convert(input, { extension_registry: registry })
-    expect(html).to.contain('<span class="emoji"><img src="https://twemoji.maxcdn.com/2/svg/1f427.svg" alt="penguin" width="42px" height="42px"></span>')
+    expect(html).to.contain('<span class="emoji"><img src="https://cdn.jsdelivr.net/npm/twemoji@latest/2/svg/1f427.svg" alt="penguin" width="42px" height="42px"></span>')
   })
   it('should convert an existing emoji into an inline image', () => {
     const input = 'emoji:black_circle[]'


### PR DESCRIPTION
When fetching https://twemoji.maxcdn.com/2/svg/XXX.svg the response status is "301 Moved Permanently" with "Location https://cdn.jsdelivr.net/npm/twemoji@latest/2/svg/XXX.svg"

To avoid redirections and  we change the CDN.

Moreover, asciidoctorjs in version 3 does not correctly manage these redirections to download images in SAFE mode. Changing the CDN works around the problem.